### PR TITLE
FEATURE(oio-exporter): the `daemons` and `nodaemons` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ An Ansible role for install oio-exporter. Specifically, the responsibilities of 
 | `openio_oio_exporter_bind_address` | `{{ openio_bind_mgmt_address \| d(ansible_default_ipv4.address) }}` |  Binding IP address. |
 | `openio_oio_exporter_bind_port` | `{{ openio_oio_exporter_default_port }}` |  Listening port. |
 | `openio_oio_exporter_default_port` | `6920` |  Default listening port. |
+| `openio_oio_exporter_daemons` | `[]` | list of daemons to activate (all if empty) |
+| `openio_oio_exporter_nodaemons` | `[]` | list of daemons to disabled (none if empty) |
 | `openio_oio_exporter_targets_group` | `openio` | The inventory group used to search for the target. |
 | `openio_oio_exporter_targets` | The node next to the current node in the previous defined group.  | A list of targets to watch. |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,10 @@ openio_oio_exporter_bind_address: "{{ openio_bind_mgmt_address | d(ansible_defau
 openio_oio_exporter_bind_port: "{{ openio_oio_exporter_default_port }}"
 openio_oio_exporter_default_port: 6920
 
+openio_oio_exporter_daemons: []
+openio_oio_exporter_nodaemons: []
+
+
 openio_oio_exporter_targets_group: openio
 
 openio_oio_exporter_targets: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,12 @@
           -healthcheck-path {{ openio_service_conf_dir }}/healthchecks.yml
           -version-path {{openio_service_conf_dir }}/versions.yml
           -targets {{ openio_oio_exporter_targets | join(',') }}
+          {% if openio_oio_exporter_daemons | length > 0 -%}
+          -daemons {{ openio_oio_exporter_daemons | join(',') }}
+          {% endif -%}
+          {% if openio_oio_exporter_nodaemons | length > 0 -%}
+          -nodaemons {{ openio_oio_exporter_nodaemons | join(',') }}
+          {% endif -%}
         redirect_stdout_to_syslog: true
         env:
           HOME: /home/openio


### PR DESCRIPTION
 ##### SUMMARY

- `openio_oio_exporter_daemons` which permit to select the daemons to run
  (all by default)
- `openio_oio_exporter_nodaemons` which permit to select the daemons no to run
  (none by default)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION