### PR TITLE
CHANGE(oio-exporter): s3rt only on first and last swift node

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,17 @@ openio_oio_exporter_default_port: 6920
 openio_oio_exporter_daemons: []
 openio_oio_exporter_nodaemons: []
 
+openio_oio_exporter_oioswift_group: oioswift
+openio_oio_exporter_disable_s3rt: |-
+  {% set ret = true %}
+  {% set _group = openio_oio_exporter_oioswift_group %}
+  {% if _group in groups and groups[_group] | length > 0 and inventory_hostname in groups[_group] %}
+  {%   set _hosts = groups[_group] | sort %}
+  {%   if inventory_hostname in [_hosts | first, _hosts | last] %}
+  {%     set ret = false %}
+  {%   endif %}
+  {% endif %}
+  {{ ret }}
 
 openio_oio_exporter_targets_group: openio
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,12 @@
           {% if openio_oio_exporter_daemons | length > 0 -%}
           -daemons {{ openio_oio_exporter_daemons | join(',') }}
           {% endif -%}
-          {% if openio_oio_exporter_nodaemons | length > 0 -%}
-          -nodaemons {{ openio_oio_exporter_nodaemons | join(',') }}
+          {% set nodaemons = openio_oio_exporter_nodaemons -%}
+          {% if openio_oio_exporter_disable_s3rt | bool -%}
+          {%   set nodaemons = nodaemons + ['s3rt'] -%}
+          {% endif -%}
+          {% if nodaemons | length > 0 -%}
+          -nodaemons {{ nodaemons | join(',') }}
           {% endif -%}
         env:
           HOME: /home/openio


### PR DESCRIPTION
 ##### SUMMARY

All nodes in the oioswift group used to launch s3rt. This PR changes
this behaviour: now only the first and the last node of the oioswift
group launch s3rt.

There is 2 new configuration related to this:
- `openio_oio_exporter_disable_s3rt`
- `openio_oio_exporter_oioswift_group`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION